### PR TITLE
Fix/t 003 substituir put patch

### DIFF
--- a/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Missoes/MissoesController.java
+++ b/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Missoes/MissoesController.java
@@ -27,13 +27,16 @@ public class MissoesController {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Não foi possível criar a missão");
     }
 
-    @PutMapping("/atualizar/{id}")
+    @PatchMapping("/atualizar/{id}")
     public ResponseEntity<?> atualizarMissao(@PathVariable Long id, @RequestBody MissoesDTO missaoAtualizada) {
-        MissoesDTO missao = missoesService.atualizarMissao(id, missaoAtualizada);
+        MissoesDTO missao = missoesService.listarMissoesPorID(id);
         if (missao == null) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("A missão a ser atualizada não foi encontrada");
         }
-        return ResponseEntity.ok(missao);
+        MissoesDTO missaoAtualizadaFinal =
+                missoesService.atualizarMissao(id, missaoAtualizada);
+
+        return ResponseEntity.ok(missaoAtualizadaFinal);
     }
 
     @GetMapping("/listar")

--- a/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Missoes/MissoesMapper.java
+++ b/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Missoes/MissoesMapper.java
@@ -27,4 +27,18 @@ public class MissoesMapper {
         return missoesDTO;
     }
 
+    public void atualizaEntidadePeloDTO(MissoesDTO dto, MissoesModel model){
+        if (dto.getNome() != null){
+            model.setNome(dto.getNome());
+        }
+
+        if(dto.getDificuldade() != null){
+            model.setDificuldade(dto.getDificuldade());
+        }
+
+        if(dto.getNinjas() != null){
+            model.setNinjas(dto.getNinjas());
+        }
+    }
+
 }

--- a/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Missoes/MissoesService.java
+++ b/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Missoes/MissoesService.java
@@ -31,14 +31,14 @@ public class MissoesService {
     }
 
     public MissoesDTO atualizarMissao(Long id, MissoesDTO missoesDTO) {
-        Optional<MissoesModel> missaoExistente = missoesRepository.findById(id);
-        if (missaoExistente.isPresent()) {
-            MissoesModel missaoAtualizada = missoesMapper.map(missoesDTO);
-            missaoAtualizada.setId(id);
-            MissoesModel missaoSalva = missoesRepository.save(missaoAtualizada);
-            return missoesMapper.map(missaoSalva);
-        }
-        return null;
+        MissoesModel missao = missoesRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Missão não encontrada"));
+
+        missoesMapper.atualizaEntidadePeloDTO(missoesDTO, missao);
+
+        MissoesModel missaoSalva = missoesRepository.save(missao);
+
+        return missoesMapper.map(missaoSalva);
     }
 
     public List<MissoesDTO> listarMissoes() {

--- a/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Ninjas/NinjaController.java
+++ b/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Ninjas/NinjaController.java
@@ -23,7 +23,7 @@ public class NinjaController {
                 .body("Ninja criado com sucesso: " + novoNinja.getNome() + " ID: " + novoNinja.getId());
     }
 
-    @PutMapping("/atualizar/{id}")
+    @PatchMapping("/atualizar/{id}")
     public ResponseEntity<NinjaDTO> atualizarNinja(@PathVariable Long id, @RequestBody NinjaDTO ninjaAtualizado) {
         NinjaDTO ninja = ninjaService.atualizarNinja(id, ninjaAtualizado);
         if (ninja == null) {

--- a/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Ninjas/NinjaDTO.java
+++ b/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Ninjas/NinjaDTO.java
@@ -13,7 +13,7 @@ public class NinjaDTO {
     private Long id;
     private String nome;
     private String email;
-    private int idade;
+    private Integer idade;
     private MissoesModel missoes;
     private String rank;
 

--- a/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Ninjas/NinjaMapper.java
+++ b/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Ninjas/NinjaMapper.java
@@ -31,4 +31,26 @@ public class NinjaMapper {
         return ninjaDTO;
     }
 
+    public void atualizaEntidadePeloDTO(NinjaDTO dto, NinjaModel model){
+        if(dto.getNome() != null){
+            model.setNome(dto.getNome());
+        }
+
+        if(dto.getEmail() != null){
+            model.setEmail(dto.getEmail());
+        }
+
+        if(dto.getIdade() != null){
+            model.setIdade(dto.getIdade());
+        }
+
+        if(dto.getMissoes() != null){
+            model.setMissoes(dto.getMissoes());
+        }
+
+        if(dto.getRank() != null){
+            model.setRank(dto.getRank());
+        }
+    }
+
 }

--- a/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Ninjas/NinjaService.java
+++ b/CadastroDeNinjas/src/main/java/dev/leefell/CadastroDeNinjas/Ninjas/NinjaService.java
@@ -26,14 +26,14 @@ public class NinjaService {
 
     // Metodo do JPA que executa automaticamente uma query SELECT * FROM na tabela de ninjas
     public NinjaDTO atualizarNinja(Long id, NinjaDTO ninjaDTO) {
-        Optional<NinjaModel> ninjaExistente = ninjaRepository.findById(id);
-        if (ninjaExistente.isPresent()) {
-            NinjaModel ninjaAtualizado = ninjaMapper.map(ninjaDTO);
-            ninjaAtualizado.setId(id);
-            NinjaModel ninjaSalvo = ninjaRepository.save(ninjaAtualizado);
-            return ninjaMapper.map(ninjaSalvo);
-        }
-        return null;
+        NinjaModel ninja = ninjaRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Ninja não encontrado"));
+
+        ninjaMapper.atualizaEntidadePeloDTO(ninjaDTO, ninja);
+
+        NinjaModel ninjaSalvo = ninjaRepository.save(ninja);
+
+        return ninjaMapper.map(ninjaSalvo);
     }
 
     public List<NinjaDTO> listarNinjas() {


### PR DESCRIPTION
Objetivo deste PR
Corrigir o comportamento de atualização parcial das entidades.

Antes deste PR, ao atualizar apenas um campo da entidade (por exemplo, nome), os demais campos eram sobrescritos com seus valores padrão devido ao uso de tipos primitivos no DTO.

Com esta correção, apenas os campos enviados na requisição são alterados, preservando os demais valores.